### PR TITLE
Reproduce 'Unresolved reference' bug

### DIFF
--- a/multiplatform/echo/build.gradle.kts
+++ b/multiplatform/echo/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
 
 val nativeTargets = arrayOf(
     "linuxX64",
-    "macosX64", "macosArm64"
+    "macosX64",
 )
 
 kotlin {
@@ -31,6 +31,8 @@ kotlin {
             dependencies {
                 implementation("org.jetbrains.kotlin:kotlin-stdlib-common")
                 implementation("me.tatarka.inject:kotlin-inject-runtime:0.3.7-SNAPSHOT")
+                implementation("io.ktor:ktor-client-core:1.6.4")
+                implementation("io.ktor:ktor-client-serialization:1.6.4")
             }
         }
     }

--- a/multiplatform/echo/src/commonMain/kotlin/App.kt
+++ b/multiplatform/echo/src/commonMain/kotlin/App.kt
@@ -1,3 +1,4 @@
+import kotlinx.serialization.json.Json
 import me.tatarka.inject.annotations.Component
 import me.tatarka.inject.annotations.Inject
 import me.tatarka.inject.annotations.Provides
@@ -7,10 +8,13 @@ typealias Args = Array<String>
 @Component
 abstract class ApplicationComponent(@get:Provides val args: Args) {
     abstract val app: App
+
+    @Provides
+    fun json(): Json = Json
 }
 
 @Inject
-class ArgProcessor(private val args: Args) {
+class ArgProcessor(private val args: Args, json: Json) {
     fun process(): String = args.joinToString(" ")
 }
 


### PR DESCRIPTION
```shell
w: [ksp] Failed to resolve annotation @Component so it's package cannot be checked. This may cause issues if you are using annotation with the same name in a different package.
e: [ksp] Unresolved reference: Json
/Users/saket/projects/kotlin-inject-samples/multiplatform/echo/src/commonMain/kotlin/App.kt:19: ArgProcessor(args: Args, json: Json)
/Users/saket/projects/kotlin-inject-samples/multiplatform/echo/src/commonMain/kotlin/App.kt:24: App(argProcessor: ArgProcessor)
/Users/saket/projects/kotlin-inject-samples/multiplatform/echo/src/commonMain/kotlin/App.kt:10: app: App
w: [ksp] Unable to process:me.tatarka.inject.compiler.ksp.InjectProcessor:   ApplicationComponent
e: java.lang.IllegalStateException: No descriptor found for type alias Args
        at org.jetbrains.kotlin.cli.metadata.MetadataSerializer$performSerialization$1.visitTypeAlias(MetadataSerializer.kt:79)
        at org.jetbrains.kotlin.psi.KtVisitorVoid.visitTypeAlias(KtVisitorVoid.java:499)
        at org.jetbrains.kotlin.psi.KtVisitorVoid.visitTypeAlias(KtVisitorVoid.java:21)
        at org.jetbrains.kotlin.psi.KtTypeAlias.accept(KtTypeAlias.kt:35)
        at org.jetbrains.kotlin.psi.KtElementImplStub.accept(KtElementImplStub.java:60)
        at org.jetbrains.kotlin.cli.metadata.MetadataSerializer.performSerialization(MetadataSerializer.kt:61)
        at org.jetbrains.kotlin.cli.metadata.MetadataSerializer.serialize(MetadataSerializer.kt:49)
        at org.jetbrains.kotlin.cli.metadata.K2MetadataCompiler.doExecute(K2MetadataCompiler.kt:112)
        at org.jetbrains.kotlin.cli.metadata.K2MetadataCompiler.doExecute(K2MetadataCompiler.kt:40)
        at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:92)
        at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:44)
        at org.jetbrains.kotlin.cli.common.CLITool.exec(CLITool.kt:98)
        at org.jetbrains.kotlin.daemon.CompileServiceImpl.compile(CompileServiceImpl.kt:1574)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at java.rmi/sun.rmi.server.UnicastServerRef.dispatch(UnicastServerRef.java:359)
        at java.rmi/sun.rmi.transport.Transport$1.run(Transport.java:200)
        at java.rmi/sun.rmi.transport.Transport$1.run(Transport.java:197)
        at java.base/java.security.AccessController.doPrivileged(Native Method)
        at java.rmi/sun.rmi.transport.Transport.serviceCall(Transport.java:196)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport.handleMessages(TCPTransport.java:562)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(TCPTransport.java:796)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(TCPTransport.java:677)
        at java.base/java.security.AccessController.doPrivileged(Native Method)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(TCPTransport.java:676)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
```