### PR TITLE
Reproduce error when two components have a cyclic dependency

### DIFF
--- a/multiplatform/echo/build.gradle.kts
+++ b/multiplatform/echo/build.gradle.kts
@@ -4,17 +4,17 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile
 
 plugins {
-    kotlin("multiplatform") version "1.5.30"
-    id("com.google.devtools.ksp") version "1.5.30-1.0.0"
+    kotlin("multiplatform") version "1.6.0-RC"
+    id("com.google.devtools.ksp") version "1.6.0-RC-1.0.1-RC"
 }
 
 dependencies {
-    ksp("me.tatarka.inject:kotlin-inject-compiler-ksp:0.3.7-SNAPSHOT")
+    ksp("me.tatarka.inject:kotlin-inject-compiler-ksp:0.3.7-RC")
 }
 
 val nativeTargets = arrayOf(
     "linuxX64",
-    "macosX64", "macosArm64"
+    "macosX64"
 )
 
 kotlin {
@@ -30,7 +30,7 @@ kotlin {
         commonMain {
             dependencies {
                 implementation("org.jetbrains.kotlin:kotlin-stdlib-common")
-                implementation("me.tatarka.inject:kotlin-inject-runtime:0.3.7-SNAPSHOT")
+                implementation("me.tatarka.inject:kotlin-inject-runtime:0.3.7-RC")
             }
         }
     }

--- a/multiplatform/echo/src/commonMain/kotlin/App.kt
+++ b/multiplatform/echo/src/commonMain/kotlin/App.kt
@@ -5,9 +5,22 @@ import me.tatarka.inject.annotations.Provides
 typealias Args = Array<String>
 
 @Component
-abstract class ApplicationComponent(@get:Provides val args: Args) {
+abstract class ApplicationComponent(
+    @get:Provides val args: Args,
+    @Component val other: OtherComponent = OtherComponent::class.create()
+) {
     abstract val app: App
+
+    @Provides fun string(): String = "bar"
 }
+
+@Component
+abstract class OtherComponent {
+    abstract val stringConsumer: StringConsumer
+}
+
+@Inject
+class StringConsumer(string: String)
 
 @Inject
 class ArgProcessor(private val args: Args) {


### PR DESCRIPTION
Context: https://kotlinlang.slack.com/archives/C0255B8KX7W/p1635740641018000

```
e: [ksp] Cannot find an @Inject constructor or provider for: String
/Users/saket/projects/kotlin-inject-samples/multiplatform/echo/src/commonMain/kotlin/App.kt:23: StringConsumer(string: String)
/Users/saket/projects/kotlin-inject-samples/multiplatform/echo/src/commonMain/kotlin/App.kt:19: stringConsumer: StringConsumer
e: java.lang.IllegalStateException: No descriptor found for type alias Args
        at org.jetbrains.kotlin.cli.metadata.MetadataSerializer$performSerialization$1.visitTypeAlias(MetadataSerializer.kt:86)
        at org.jetbrains.kotlin.psi.KtVisitorVoid.visitTypeAlias(KtVisitorVoid.java:499)
        at org.jetbrains.kotlin.psi.KtVisitorVoid.visitTypeAlias(KtVisitorVoid.java:21)
        at org.jetbrains.kotlin.psi.KtTypeAlias.accept(KtTypeAlias.kt:35)
        at org.jetbrains.kotlin.psi.KtElementImplStub.accept(KtElementImplStub.java:49)
        at org.jetbrains.kotlin.cli.metadata.MetadataSerializer.performSerialization(MetadataSerializer.kt:68)
        at org.jetbrains.kotlin.cli.metadata.MetadataSerializer.serialize(MetadataSerializer.kt:55)
        at org.jetbrains.kotlin.cli.metadata.K2MetadataCompiler.doExecute(K2MetadataCompiler.kt:117)
        at org.jetbrains.kotlin.cli.metadata.K2MetadataCompiler.doExecute(K2MetadataCompiler.kt:40)
        at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:92)
        at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:44)
        at org.jetbrains.kotlin.cli.common.CLITool.exec(CLITool.kt:98)
        at org.jetbrains.kotlin.daemon.CompileServiceImpl.compile(CompileServiceImpl.kt:1618)
```