### PR TITLE
Update Greeter dependencies and simplify build

### DIFF
--- a/multiplatform/greeter/androidApp/build.gradle.kts
+++ b/multiplatform/greeter/androidApp/build.gradle.kts
@@ -32,7 +32,7 @@ android {
 }
 
 dependencies {
-  implementation(project(":shared"))
+  implementation(projects.shared)
   implementation(libs.androidx.activity.compose)
   implementation(platform(libs.compose.bom))
   implementation(libs.compose.foundation)

--- a/multiplatform/greeter/gradle/libs.versions.toml
+++ b/multiplatform/greeter/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
 agp = '7.4.2'
 androidx-activity = '1.6.1'
-compose-bom = '2023.01.00' # https://developer.android.com/jetpack/compose/bom/bom-mapping
-compose-compiler = '1.4.3'
-kotlin = '1.8.10'
+compose-bom = '2023.03.00' # https://developer.android.com/jetpack/compose/bom/bom-mapping
+compose-compiler = '1.4.5'
+kotlin = '1.8.20'
 kotlinInject = '0.6.1'
-ksp = '1.8.10-1.0.9'
+ksp = '1.8.20-1.0.10'
 
 [libraries]
 androidx-activity-compose = { module = 'androidx.activity:activity-compose', version.ref = 'androidx-activity' }

--- a/multiplatform/greeter/settings.gradle.kts
+++ b/multiplatform/greeter/settings.gradle.kts
@@ -16,3 +16,6 @@ dependencyResolutionManagement {
 rootProject.name = "kotlin-inject-greeter"
 include(":androidApp")
 include(":shared")
+
+// https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:type-safe-project-accessors
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")

--- a/multiplatform/greeter/shared/build.gradle.kts
+++ b/multiplatform/greeter/shared/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
 kotlin {
-  targetHierarchy.default()
+  targetHierarchy.default() // https://kotlinlang.org/docs/whatsnew1820.html#new-approach-to-source-set-hierarchy
 
   android()
 

--- a/multiplatform/greeter/shared/build.gradle.kts
+++ b/multiplatform/greeter/shared/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
   alias(libs.plugins.ksp)
 }
 
+@OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
 kotlin {
   targetHierarchy.default()
 

--- a/multiplatform/greeter/shared/build.gradle.kts
+++ b/multiplatform/greeter/shared/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
 }
 
 kotlin {
+  targetHierarchy.default()
+
   android()
 
   listOf(
@@ -27,26 +29,6 @@ kotlin {
       dependencies {
         implementation(kotlin("test"))
       }
-    }
-    val androidMain by getting
-    val androidUnitTest by getting
-    val iosX64Main by getting
-    val iosArm64Main by getting
-    val iosSimulatorArm64Main by getting
-    val iosMain by creating {
-      dependsOn(commonMain)
-      iosX64Main.dependsOn(this)
-      iosArm64Main.dependsOn(this)
-      iosSimulatorArm64Main.dependsOn(this)
-    }
-    val iosX64Test by getting
-    val iosArm64Test by getting
-    val iosSimulatorArm64Test by getting
-    val iosTest by creating {
-      dependsOn(commonTest)
-      iosX64Test.dependsOn(this)
-      iosArm64Test.dependsOn(this)
-      iosSimulatorArm64Test.dependsOn(this)
     }
   }
 }


### PR DESCRIPTION
This PR is a follow up on [this comment](https://github.com/evant/kotlin-inject-samples/pull/7#discussion_r1161960130). Now that we have a Compose compiler version compatible with Kotlin 1.8.20, I'm basically bumping everything and adding the [new way of setting up source set hierarchy](https://kotlinlang.org/docs/whatsnew1820.html#new-approach-to-source-set-hierarchy).

I'm also enabling [Gradle's typesafe project accessors](https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:type-safe-project-accessors) as an unrelated minor improvement.